### PR TITLE
Allow for loading of truly raw esp32 logs

### DIFF
--- a/src/main_window.py
+++ b/src/main_window.py
@@ -408,7 +408,7 @@ class MainWindow(QMainWindow):
                         try:
                             # Parse Header
                             # Expected: Time, Foo, Bar, Baz, ...
-                            # Note: first line (header) may be optionally prepended with %
+                            # Note: first line (header) must be prepended with %
                             # Convert to: "Foo","Bar",...
                             header = [h.replace('%', '').strip() for h in row]
                             header = list(dict.fromkeys(header))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* don't assume the header is the first row when loading raw files
* don't assume every line can be parsed as a csv row
* assume that raw logs contain '%' as the first line of the header

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows us to load truly raw files (uart logs from esp32) which _contain_ header / csv rows but can also contain other (useful) information such as errors and other types of logs.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
By loading this file:
[test_output_7_fixed_rotary_encoder.csv](https://github.com/appliedinnovation/uart_serial_plotter/files/9256042/test_output_7_fixed_rotary_encoder.csv)

which contains:

```console
I (0) cpu_start: App cpu up.
I (446) cpu_start: Pro cpu start user code
I (446) cpu_start: cpu freq: 240000000 Hz
I (446) cpu_start: Application information:
I (449) cpu_start: Project name:     push_brake_detection
I (455) cpu_start: App version:      e399899-dirty
I (461) cpu_start: Compile time:     Aug  3 2022 10:54:03
I (467) cpu_start: ELF file SHA256:  875a3eb6dac879ce...
I (473) cpu_start: ESP-IDF:          v5.0-dev-2996-gb531745a11-dirty
I (480) heap_init: Initializing. RAM available for dynamic allocation:
I (487) heap_init: At 3FCA4870 len 0003B790 (237 KiB): D/IRAM
I (494) heap_init: At 3FCE0000 len 0000EE34 (59 KiB): STACK/DRAM
I (500) heap_init: At 3FCF0000 len 00008000 (32 KiB): DRAM
I (506) heap_init: At 600FE000 len 00002000 (8 KiB): RTCRAM
I (513) spi_flash: detected chip: generic
I (517) spi_flash: flash io: dio
I (535) gpio: GPIO[2]| InputEn: 0| OutputEn: 1| OpenDrain: 0| Pullup: 1| Pulldown: 0| Intr:0
I (536) gpio: GPIO[14]| InputEn: 0| OutputEn: 1| OpenDrain: 0| Pullup: 1| Pulldown: 0| Intr:0
I (543) gpio: GPIO[15]| InputEn: 0| OutputEn: 1| OpenDrain: 0| Pullup: 1| Pulldown: 0| Intr:0
I (556) sleep: Configure to isolate all GPIO pins in sleep state
I (559) sleep: Enable automatic switching of GPIO sleep configuration
I (566) cpu_start: Starting scheduler on PRO CPU.
I (0) cpu_start: Starting scheduler on APP CPU.
I (582) gpio: GPIO[16]| InputEn: 1| OutputEn: 0| OpenDrain: 0| Pullup: 1| Pulldown: 1| Intr:0
I (592) gpio: GPIO[8]| InputEn: 0| OutputEn: 1| OpenDrain: 0| Pullup: 1| Pulldown: 1| Intr:0
I (617) pp: pp rom version: e7ae62f
I (618) net80211: net80211 rom version: e7ae62f
I (619) wifi:wifi driver task: 3fce7448, prio:23, stack:6656, core=0
I (622) system_api: Base MAC address is not set
I (627) system_api: read default base MAC address from EFUSE
I (638) wifi:wifi firmware version: 93a1ecf
I (638) wifi:wifi certification version: v7.0
I (641) wifi:config NVS flash: enabled
I (645) wifi:config nano formating: disabled
I (649) wifi:Init data frame dynamic rx buffer num: 32
I (654) wifi:Init management frame dynamic rx buffer num: 32
I (659) wifi:Init management short buffer num: 32
I (663) wifi:Init dynamic tx buffer num: 32
I (667) wifi:Init static tx FG buffer num: 2
I (671) wifi:Init static rx buffer size: 1600
I (675) wifi:Init static rx buffer num: 10
I (679) wifi:Init dynamic rx buffer num: 32
I (683) wifi_init: rx ba win: 6
I (687) wifi_init: tcpip mbox: 32
I (691) wifi_init: udp mbox: 6
I (695) wifi_init: tcp mbox: 6
I (698) wifi_init: tcp tx win: 5744
I (702) wifi_init: tcp rx win: 5744
I (707) wifi_init: tcp mss: 1440
I (711) wifi_init: WiFi IRAM OP enabled
I (715) wifi_init: WiFi RX IRAM OP enabled
E (1393) wifi:Cannot set pmf to required when in wpa-wpa2 mixed mode! Setting pmf to optional mode.
I (1394) phy_init: phy_version 501,79e7e9b,Apr 19 2022,11:10:08
I (1489) wifi:mode : softAP (7c:df:a1:e1:fc:85)
I (1492) wifi:Total power save buffer number: 16
I (1492) wifi:Init max length of beacon: 752/752
I (1493) wifi:Init max length of beacon: 752/752
I (3524) wifi:new:<1,1>, old:<1,1>, ap:<1,1>, sta:<255,255>, prof:1
I (3525) wifi:station: 24:62:ab:f9:83:8c join, AID=1, bgn, 40U
Wifi: Station connected! MAC=24:62:ab:f9:83:8c, AD=1
I (3595) esp_netif_lwip: DHCP server assigned IP to a client, IP is: 192.168.2.2
W (5321) wifi:<ba-add>idx:2 (ifx:1, 24:62:ab:f9:83:8c), tid:0, ssn:0, winSize:64
Imu: Self-test failure !
Imu: rc: 0
Imu: Error enable sensors.
Task: Task '' cannot be stopped - it is not running.
Imu: Self-test failure !
Imu: rc: 0
Imu: Error enable sensors.
Task: Task '' cannot be stopped - it is not running.
I (31916) gpio: GPIO[41]| InputEn: 1| OutputEn: 0| OpenDrain: 0| Pullup: 1| Pulldown: 0| Intr:0
I (31916) gpio: GPIO[40]| InputEn: 1| OutputEn: 0| OpenDrain: 0| Pullup: 1| Pulldown: 0| Intr:0
I (31924) gpio: GPIO[40]| InputEn: 1| OutputEn: 0| OpenDrain: 0| Pullup: 1| Pulldown: 0| Intr:0
I (31934) gpio: GPIO[41]| InputEn: 1| OutputEn: 0| OpenDrain: 0| Pullup: 1| Pulldown: 0| Intr:0
I (31945) gpio: GPIO[9]| InputEn: 0| OutputEn: 1| OpenDrain: 0| Pullup: 0| Pulldown: 1| Intr:0
I (31953) gpio: GPIO[21]| InputEn: 0| OutputEn: 1| OpenDrain: 0| Pullup: 0| Pulldown: 1| Intr:0
I (31962) gpio: GPIO[47]| InputEn: 0| OutputEn: 1| OpenDrain: 0| Pullup: 0| Pulldown: 1| Intr:0
I (31972) gpio: GPIO[7]| InputEn: 1| OutputEn: 0| OpenDrain: 0| Pullup: 0| Pulldown: 0| Intr:0
I (31984) gpio: GPIO[3]| InputEn: 0| OutputEn: 0| OpenDrain: 0| Pullup: 0| Pulldown: 0| Intr:0
BSP initialized!
%% time(s),linear_accel_x,linear_accel_y,linear_accel_z,grav_x,grav_y,grav_z,speed(rpm),encoder_acc,pwm,slope,cross_slope
PBD: wifi ps mode:1
I (32009) wifi:Set ps type: 2

PBD: wifi ps mode:2
31.584,-0.772,0.012,-1.610,0.000,0.000,0.000,0.000,0.000,0.000,63.414,177.159
PBD: create file transfer thread.
HeapManager:           Biggest /     Free /    Total
DRAM  : [   94208 /   102496 /   345540]
PSRAM : [       0 /        0 /        0]
I (32052) perfmon:
Name:			CPU %:	High Water Mark:
perfmon			<1%	3752
imu task		<1%	6044
main			5%	1136
IDLE			97%	776
IDLE			89%	772
power_switch co		<1%	3020
encoder_vel_loo		<1%	4872
data_logging		<1%	2584
motor_controlle		<1%	6756
tiT			<1%	1444
data_logging		<1%	3540
motor_error_han		<1%	3096
comm_secondary 		<1%	1112
adc_continuous_		<1%	2736
Tmr Svc			<1%	1404
ipc1			1%	332
sys_evt			<1%	2124
rotcon/command 		<1%	4780
esp_timer		<1%	3164
wifi			2%	4044
file_control ud		<1%	4776
CommMain		<1%	996
ipc0			1%	376

31.624,-0.760,-0.010,-1.609,0.000,0.000,0.000,0.000,0.000,0.000,63.470,177.357
PBD: Timeout check
31.665,-0.766,-0.006,-1.609,0.000,0.000,0.000,0.000,0.000,0.000,62.972,177.275
31.706,-0.753,-0.004,-1.622,0.000,0.000,0.000,0.000,0.000,0.000,63.198,177.435
31.746,-0.750,-0.001,-1.613,0.000,0.000,0.000,0.000,0.000,0.000,62.832,177.470
31.786,-0.745,-0.004,-1.625,0.000,0.000,0.000,0.000,0.000,0.000,62.955,177.544
31.826,-0.745,-0.009,-1.617,0.000,0.000,0.000,0.000,0.000,0.000,62.363,177.469
31.866,-0.739,-0.003,-1.603,0.000,0.000,0.000,0.000,0.000,0.000,62.008,177.454
31.906,-0.716,-0.009,-1.618,0.000,0.000,0.000,0.000,0.000,0.000,62.541,177.509
31.946,-0.715,-0.002,-1.626,0.000,0.000,0.000,0.000,0.000,0.000,62.368,177.468
31.986,-0.719,-0.003,-1.607,0.000,0.000,0.000,0.000,0.000,0.000,61.656,177.392
32.027,-0.700,0.002,-1.624,0.000,0.000,0.000,0.000,0.000,0.000,61.929,177.657
32.067,-0.688,-0.007,-1.610,0.000,0.000,0.000,0.000,0.000,0.000,61.793,177.679
32.107,-0.698,-0.010,-1.611,0.000,0.000,0.000,0.000,0.000,0.000,61.130,177.812
32.147,-0.681,-0.010,-1.616,0.000,0.000,0.000,0.000,0.000,0.000,61.547,177.868
32.187,-0.695,-0.005,-1.604,0.000,0.000,0.000,0.000,0.000,0.000,60.640,177.938
32.227,-0.689,-0.004,-1.608,0.000,0.000,0.000,0.000,0.000,0.000,60.349,177.951
32.267,-0.658,-0.005,-1.609,0.000,0.000,0.000,0.000,0.000,0.000,60.957,177.899
32.307,-0.665,-0.007,-1.616,0.000,0.000,0.000,0.000,0.000,0.000,60.492,177.922
32.347,-0.655,-0.008,-1.594,0.000,0.000,0.000,0.000,0.000,0.000,60.168,178.062
32.387,-0.659,-0.010,-1.601,0.000,0.000,0.000,0.000,0.000,0.000,59.809,178.074
32.427,-0.644,0.008,-1.610,0.000,0.000,0.000,0.000,0.000,0.000,60.180,178.098
32.467,-0.645,-0.015,-1.603,0.000,0.000,0.000,0.000,0.000,0.000,59.563,178.074
32.507,-0.633,0.003,-1.604,0.000,0.000,0.000,0.000,0.000,0.000,59.580,178.086
32.547,-0.633,-0.009,-1.602,0.000,0.000,0.000,0.000,0.000,0.000,59.178,178.195
32.587,-0.616,-0.006,-1.606,0.000,0.000,0.000,0.000,0.000,0.000,59.223,178.175
32.627,-0.610,0.004,-1.603,0.000,0.000,0.000,0.000,0.000,0.000,59.036,178.202
PBD: Timeout check
32.667,-0.602,-0.008,-1.601,0.000,0.000,0.000,0.000,0.000,0.000,58.919,178.214
```

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
<img width="1719" alt="CleanShot 2022-08-03 at 20 45 31@2x" src="https://user-images.githubusercontent.com/213467/182745203-bbf4cccf-bca2-4d78-ab37-2f15dac9f99b.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.

### Hardware
- [ ] I have updated the design files (schematic, board, libraries).
- [ ] I have attached the PDFs of the SCH / BRD to this PR
- [ ] I have updated the design output (GERBER, BOM) files.
