### PR TITLE
feat: allow raw files to be either CSV or TXT

### DIFF
--- a/src/main_window.py
+++ b/src/main_window.py
@@ -382,9 +382,9 @@ class MainWindow(QMainWindow):
 
     def __open_raw__(self):
         dialog = QFileDialog()
-        fmt = "csv"
-        dialog.setDefaultSuffix(fmt)
-        dialog.setNameFilters([f"{fmt} (*.{fmt})"])
+        fmts = ["Any Text Files (*.csv *.txt)", "CSV (*csv)", "Text (*txt)"]
+        dialog.setDefaultSuffix(fmts[0])
+        dialog.setNameFilters(fmts)
 
         if dialog.exec_() == QDialog.Accepted:
             path = dialog.selectedFiles()[0]
@@ -433,9 +433,9 @@ class MainWindow(QMainWindow):
 
     def __import_scene__(self):
         dialog = QFileDialog()
-        fmt = "csv"
-        dialog.setDefaultSuffix(fmt)
-        dialog.setNameFilters([f"{fmt} (*.{fmt})"])
+        fmts = ["CSV (*csv)"]
+        dialog.setDefaultSuffix(fmts[0])
+        dialog.setNameFilters(fmts)
 
         if dialog.exec_() == QDialog.Accepted:
             path = dialog.selectedFiles()[0]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Allow `Open RAW csv files` dialog to support `*.csv`, `*.txt` and both `*.csv, *.txt` files, default to both

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When we save the UART output it defaults to `*.txt` files, so it would be nice to be able to load those back into the program with the `RAW` dialog, which is what it was designed to load.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Opening *.csv and *.txt files and seeing them plotted :)

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
### Open Raw CSV (support TXT and CSV files)
![CleanShot 2022-08-17 at 08 25 56](https://user-images.githubusercontent.com/213467/185145658-82d7baba-f43d-4c56-a3e3-f89a24960594.png)
![CleanShot 2022-08-17 at 08 26 14](https://user-images.githubusercontent.com/213467/185146060-1e4db1fc-5feb-4c87-b6b6-84bb54fa1d62.png)
![CleanShot 2022-08-17 at 08 30 16](https://user-images.githubusercontent.com/213467/185146632-48040658-1da4-43f8-afef-7d63db5e4e23.png)

### Open CSV Files Only
![CleanShot 2022-08-17 at 08 26 44](https://user-images.githubusercontent.com/213467/185145843-da51721a-dd06-43f0-b480-117b3aa40685.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.

### Hardware
- [ ] I have updated the design files (schematic, board, libraries).
- [ ] I have attached the PDFs of the SCH / BRD to this PR
- [ ] I have updated the design output (GERBER, BOM) files.
